### PR TITLE
Fixes #9 - Use child_process.spawn so process output cap is not exceeded on Mac OSX High Sierra

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -19,13 +19,12 @@ class ChromeDriverLauncher {
         this.logToStdout = config.logToStdout
 
         return new Promise((resolve, reject) => {
-            this.process = childProcess.execFile(binPath, this.chromeDriverArgs, (err, stdout, stderr) => {
-                if (err) {
-                    return reject(err)
-                }
-            })
+            this.process = childProcess.spawn(binPath, this.chromeDriverArgs)
 
             if (this.process) {
+                this.process.on('error', (err) => {
+                    reject(err)
+                })
                 if (typeof this.chromeDriverLogs === 'string') {
                     this._redirectLogStream()
                 }


### PR DESCRIPTION
Chromedriver causes a lot of warning output on Mac OSX High Sierra (I have version 10.13.6).  This exceeds the max output allowed by default by child_process.execFile, causing the chromedriver process to be terminated.

node-chromedriver fixed this issue: https://github.com/giggio/node-chromedriver/issues/150 but wdio-chromedriver-service needs a similar fix.