### PR TITLE
Chromedriver service uses port & path from config

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -18,6 +18,14 @@ class ChromeDriverLauncher {
         this.chromeDriverLogs = config.chromeDriverLogs
         this.logToStdout = config.logToStdout
 
+        if (!this.chromeDriverArgs.find(arg => arg.startsWith('--port'))) {
+            this.chromeDriverArgs.push(`--port=${config.port}`);
+        }
+
+        if (!this.chromeDriverArgs.find(arg => arg.startsWith('--url-base'))) {
+            this.chromeDriverArgs.push(`--url-base=${config.path}`);
+        }
+
         return new Promise((resolve, reject) => {
             this.process = childProcess.execFile(binPath, this.chromeDriverArgs, (err, stdout, stderr) => {
                 if (err) {


### PR DESCRIPTION
This change makes it so the chromedriver service uses the port and path defined in `wdio.conf.js` rather than the other way round. This makes it easier to install and use the service, without having to worry about configuring special configuration specifically for chromedriver.path defined.

For example, when installing the chromedriver service via the `wdio config` wizard, it is not clear that you have to update the path and port in order to make it work. With this change, it would always work regardless of how port and path are defined.