### PR TITLE
accept any version of chromedriver as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/atti187/wdio-chromedriver-service/issues"
   },
   "peerDependencies": {
-    "chromedriver": "^2.45.0",
+    "chromedriver": "*",
     "@wdio/cli": "^5.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
The `chromedriver` package moved from `v2.46.0` to `v73.0.0`, then `v74.0.0`.  So every new version is a new major version, so to avoid peer dependency warnings I've changed this to `"*"` (accept any version).