### PR TITLE
Allow to set log file name + minor bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Type: `number`
 ### path
 The path on which the driver should run on
 
-Example:  `/wd/hub`
+Example:  `/`
 
 Type: `string`
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ export.config = {
   // ...
   services: [
     ['chromedriver', {
+        logFileName: 'wdio-chromedriver.log', // default
         outputDir: 'driver-logs', // overwrites the config.outputDir
-        args: ['--silent'] //
+        args: ['--silent']
     }]
   ],
   // ...
@@ -102,7 +103,12 @@ Example: `driver-logs`
 
 Type: `string`
 
+### logFileName
+The name of the log file to be written in `outputDir`.
 
+Example: `wdio-chromedriver.log`
+
+Type: `string`
 
 ----
 

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -3,7 +3,7 @@ import ChromeDriver from 'chromedriver'
 
 import getFilePath from './utils/getFilePath'
 
-const DEFAULT_LOG_FILENAME = 'chromedriver.log'
+const DEFAULT_LOG_FILENAME = 'wdio-chromedriver.log'
 
 const DEFAULT_CONNECTION = {
     protocol: 'http',
@@ -25,6 +25,7 @@ export default class ChromeDriverLauncher {
         }
 
         this.outputDir = options.outputDir || config.outputDir
+        this.logFileName = options.logFileName || DEFAULT_LOG_FILENAME
         this.capabilities = capabilities
         this.args = options.args || []
     }
@@ -60,7 +61,7 @@ export default class ChromeDriverLauncher {
     }
 
     _redirectLogStream() {
-        const logFile = getFilePath(this.outputDir, DEFAULT_LOG_FILENAME)
+        const logFile = getFilePath(this.outputDir, this.logFileName)
 
         // ensure file & directory exists
         fs.ensureFileSync(logFile)
@@ -73,8 +74,8 @@ export default class ChromeDriverLauncher {
     _mapCapabilities() {
         if (isMultiremote(this.capabilities)) {
             for (const cap in this.capabilities) {
-                if (isChrome(this.capabilities[cap])) {
-                    Object.assign(this.capabilities[cap], this.options)
+                if (isChrome(this.capabilities[cap].capabilities)) {
+                    Object.assign(this.capabilities[cap].capabilities, this.options)
                 }
             }
         } else {

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -75,7 +75,7 @@ export default class ChromeDriverLauncher {
         if (isMultiremote(this.capabilities)) {
             for (const cap in this.capabilities) {
                 if (isChrome(this.capabilities[cap].capabilities)) {
-                    Object.assign(this.capabilities[cap].capabilities, this.options)
+                    Object.assign(this.capabilities[cap], this.options)
                 }
             }
         } else {

--- a/tests/launcher.test.js
+++ b/tests/launcher.test.js
@@ -28,8 +28,16 @@ describe('ChromeDriverLauncher launcher', () => {
             { browserName: 'firefox' }
         ]
         multiremoteCaps = {
-            myCustomChromeBrowser: { browserName: 'chrome' },
-            myCustomFirefoxBrowser: { browserName: 'firefox' }
+            myCustomChromeBrowser: {
+                capabilities: {
+                    browserName: 'chrome'
+                }
+            },
+            myCustomFirefoxBrowser: {
+                capabilities: {
+                    browserName: 'firefox'
+                }
+            }
         }
     })
 
@@ -170,14 +178,18 @@ describe('ChromeDriverLauncher launcher', () => {
 
             expect(Launcher.capabilities).toEqual({
                 myCustomChromeBrowser: {
-                    browserName: 'chrome',
                     protocol: 'http',
                     hostname: 'localhost',
                     port: 9515,
-                    path: '/'
+                    path: '/',
+                    capabilities: {
+                        browserName: 'chrome',
+                    }
                 },
                 myCustomFirefoxBrowser: {
-                    browserName: 'firefox'
+                    capabilities: {
+                        browserName: 'firefox'
+                    }
                 }
             })
         })
@@ -317,7 +329,7 @@ describe('ChromeDriverLauncher launcher', () => {
 
             await Launcher.onPrepare()
 
-            expect(fs.createWriteStream.mock.calls[0][0]).toBe(path.join(process.cwd(), 'dummy', 'chromedriver.log'))
+            expect(fs.createWriteStream.mock.calls[0][0]).toBe(path.join(process.cwd(), 'dummy', 'wdio-chromedriver.log'))
             expect(Launcher.process.stdout.pipe).toBeCalled()
             expect(Launcher.process.stderr.pipe).toBeCalled()
         })


### PR DESCRIPTION
Hey,
this patch contains following patches:

- fix usage of multiremote, which have capabilities set as follows:

  ```js
  capabilities: {
        myChromeBrowser: {
            port: 4446,
            capabilities: {
                browserName: 'chrome',
                acceptInsecureCerts: true
            }
        },
        myFFBrowser: {
            port: 4445,
            capabilities: {
                browserName: 'firefox',
                acceptInsecureCerts: true
            }
        }
    },
- add option to allow setting custom log file name because why not 🤷‍♂️
- rename default log file name for chromedriver to `wdio-chromedriver.log` to align with the other wdio specific log files.

Cheers