### PR TITLE
Reinstate newlines in README version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ WDIO ChromeDriver Service
 
 (Based entirely on [wdio-selenium-standalone-service](https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-selenium-standalone-service).)
 
-Note:
-If you're working with WebdriverIO v7, use version 7.X.X
-If you're working with WebdriverIO v6, use version 6.X.X
+Note:\
+If you're working with WebdriverIO v7, use version 7.X.X\
+If you're working with WebdriverIO v6, use version 6.X.X\
 If you're working with WebdriverIO v5, use version 5.X.X
 
 ----


### PR DESCRIPTION
Sorry for the noise here. Turns out the github diff viewer didn't show that some of the backslashes I removed in the previous commit were needed after all. 🤦 Hopefully this will fix things.